### PR TITLE
fix(docs): update events list to match with types

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,12 @@ taWebsocket.taClient.on("EVENT_NAME", (e) => {
 
 #### Supported Events
 
-- `coordinatorAdded`
-- `coordinatorLeft`
 - `matchCreated`
 - `matchUpdated`
 - `matchDeleted`
-- `playerAdded`
-- `playerUpdated`
-- `playerLeft`
+- `userAdded`
+- `userUpdated`
+- `userLeft`
 - `qualifierEventCreated`
 - `qualifierEventUpdated`
 - `qualifierEventDeleted`


### PR DESCRIPTION
Events in docs are not matching with the ones in [type declaration](https://github.com/Dannypoke03/TournamentAssistantClient/blob/main/src/models/_EventEmitter.ts#L17)